### PR TITLE
adds minNativeZoom and maxNativeZoom

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -37,7 +37,7 @@ This example uses the [Leaflet](http://leafletjs.com/) library for interactive m
 
 
 ###Preparing the map
-The first step is to setup the leaflet map. Include the Leaflet css and javascript files in the head of your page. 
+The first step is to setup the leaflet map. Include the Leaflet css and javascript files in the head of your page.
 ```html
 <head>
 ...
@@ -91,11 +91,11 @@ https://api.wxtiles.com/v0/wxtiles/tile/ncep-mrms-us-reflectivity/QCComposite/20
 The {z}, {x}, and {y} parameters will be filled in by the map library when it requests tiles. Now we just need construct another layer with our url and add it to the map.  
 ```js
 var lightningLayer = L.tileLayer('https://api.wxtiles.com/v0/wxtiles/tile/ncep-mrms-us-reflectivity/QCComposite/2016-07-17T21:16:37Z/0/{z}/{x}/{y}.png', {
-		maxZoom: 9,
+		maxNativeZoom: 11,
 		tms: true
 	}).addTo(leafletMap);
 ```
-Note: We must set tms to true so Leaflet knows to flip the y coordinate when requesting tiles. See the bottom of [this page](http://leafletjs.com/examples/wms/wms.html) for more information. 
+Note: We must set tms to true so Leaflet knows to flip the y coordinate when requesting tiles. See the bottom of [this page](http://leafletjs.com/examples/wms/wms.html) for more information.
 
 ![Leaflet example map with overlay](./getting-started/map-with-layer-small.png "Leaflet example map with overlay")
 
@@ -176,6 +176,8 @@ This will get all the layers provided by WXTiles and log them to the console, wh
         "created": "2016-07-19T01:21:32.212193Z"
       }
     ],
+    "minNativeZoom": 1,
+    "maxNativeZoom": 11,
     "bounds": {
       "west": -129.9975,
       "east": -60.002502,
@@ -260,8 +262,8 @@ The URL of a tile contains a number of parameters that must be substituted into 
 ```
 https://api.wxtiles.com/v0/{ownerId}/tile/{layerId}/{instanceId}/{time}/{level}/{z}/{x}/{y}.{extension}
 ```
-  
-  
+
+
 | Parameter     | Example       						          | Meaning
 | -------------	| -------------							          | -----
 | ownerId       | wxtiles								              | The owner of the dataset.
@@ -273,4 +275,3 @@ https://api.wxtiles.com/v0/{ownerId}/tile/{layerId}/{instanceId}/{time}/{level}/
 | x     		    | 38									                | The map x position. Set by the map library.
 | y     		    | 78									                | The map x position. Set by the map library.
 | extension	    | png									                | PNG
-

--- a/swagger-definitions/swagger.yaml
+++ b/swagger-definitions/swagger.yaml
@@ -362,6 +362,9 @@ definitions:
   Layer:
     type: object
     description: A layer representing a spatial dataset that can be rendered by Cloudburst
+    required:
+      - minNativeZoom
+      - maxNativeZoom
     properties:
       id:
         type: string
@@ -426,7 +429,7 @@ definitions:
   MaxNativeZoom:
     type: number
     format: integer
-    description: The largest scale supported natively by the layer. 
+    description: The largest scale supported natively by the layer.
   Resources:
     type: object
     description: Template URLs for requesting tiles and other resources for this layer instance. Note that the tile coordinates (z, x, and y) must be given in OGC TMS, rather than the XYZ specification (see https://gist.github.com/tmcw/4954720 for the difference, which only affects the y coordinate). Not all given properties exist for all layers. The literal text "instance" (enclosed in angle brackets) must be substituted by a valid instance ID.

--- a/swagger-definitions/swagger.yaml
+++ b/swagger-definitions/swagger.yaml
@@ -373,6 +373,10 @@ definitions:
           $ref: '#/definitions/Instance'
       bounds:
         $ref: '#/definitions/Bounds'
+      minNativeZoom:
+        $ref: '#/definitions/MinNativeZoom'
+      maxNativeZoom:
+        $ref: '#/definitions/MaxNativeZoom'
       meta:
         $ref: '#/definitions/Metadata'
       resources:
@@ -415,6 +419,14 @@ definitions:
         type: number
         format: float
         description: The southern extent of the instance's dataset (degrees longitude)
+  MinNativeZoom:
+    type: number
+    format: integer
+    description: The smallest scale supported natively by the layer.
+  MaxNativeZoom:
+    type: number
+    format: integer
+    description: The largest scale supported natively by the layer. 
   Resources:
     type: object
     description: Template URLs for requesting tiles and other resources for this layer instance. Note that the tile coordinates (z, x, and y) must be given in OGC TMS, rather than the XYZ specification (see https://gist.github.com/tmcw/4954720 for the difference, which only affects the y coordinate). Not all given properties exist for all layers. The literal text "instance" (enclosed in angle brackets) must be substituted by a valid instance ID.


### PR DESCRIPTION
Before merging, need additional commit(s):
 - check no other adjustments needs
 - build swagger

This adds documentation of the `minNativeZoom` and `maxNativeZoom` properties of a layer that can be used to autoscale tiles beyond the range supported by a layer.