### PR TITLE
adds instance details information

### DIFF
--- a/swagger-definitions/swagger.yaml
+++ b/swagger-definitions/swagger.yaml
@@ -373,6 +373,12 @@ definitions:
           $ref: '#/definitions/Instance'
       bounds:
         $ref: '#/definitions/Bounds'
+      instanceType:
+        type: string
+        description: One of a typology of instance types. Currently these are "cyclic" (for model cycles), and "observational" (for observational timestamps).
+      instanceDescription:
+        type: string
+        description: Free-form text explaining the role of instances for the associated layer
       meta:
         $ref: '#/definitions/Metadata'
       resources:
@@ -384,15 +390,9 @@ definitions:
       id:
         type: string
         description: Instance ID
-      name:
+      displayName:
         type: string
         description: Instance name, intended for display to end users
-      type:
-        type: string
-        description: One of a typology of instance types. Currently these are "cyclic" (for model cycles), "observational" (for observational timestamps), and "model" (for classes of scientific models)
-      description:
-        type: string
-        description: Free-form text explaining the role of instances for the associated layer
       created:
         type: string
         format: date-time

--- a/swagger-definitions/swagger.yaml
+++ b/swagger-definitions/swagger.yaml
@@ -384,8 +384,18 @@ definitions:
       id:
         type: string
         description: Instance ID
+      name:
+        type: string
+        description: Instance name, intended for display to end users
+      type:
+        type: string
+        description: One of a typology of instance types. Currently these are "cyclic" (for model cycles), "observational" (for observational timestamps), and "model" (for classes of scientific models)
+      description:
+        type: string
+        description: Free-form text explaining the role of instances for the associated layer
       created:
         type: string
+        format: date-time
         description: ISO 8601 datetime string representing when the instance configuration was created
       start_time:
         type: string


### PR DESCRIPTION
In the next release, there will be additional information available about instances, including a typology of instance types that should aid in interpretation of instances (`cyclic`, `observational`, and `model`). I've made an initial commit but I want to discuss how we explain the instance concepts to users, as it is an area of confusion for many.

Also I'm not sure how to express in the `swagger.yaml` that a property may be null. All of the new properties introduced here are nullable.

As an example of the end product, and instance entity in the wxtiles API will might shortly look like:

```json
{
    "end": "2015-09-29T12:00:00Z",
    "name": "2015-09-22T12:00:00Z",
    "created": "2016-09-01T06:00:13.958631Z",
    "start": "2015-09-22T12:00:00Z",
    "type": "cyclic",
    "id": "20150922_12",
    "description": "NCEP model run"
}
```

Where once it was:

```json
{
    "start": "2016-08-31T00:00:00Z",
    "end": "2016-08-31T03:00:00Z",
    "id": "20160831_00",
    "created": "2016-09-01T05:46:34.317571Z"
}
```

Note that `name` is often an ISO8601 datetime, but is not constrained to be, it should just be considered presentable text.

Also worth discussing is whether we want instance `type` and `description` to live within a layer, as they are the same for all instances of a layer.